### PR TITLE
Replace disable log_bin config

### DIFF
--- a/edge-node-installer.sh
+++ b/edge-node-installer.sh
@@ -80,7 +80,7 @@ echo "alias otnode-config='nano ~/ot-node/.origintrail_noderc'" >> ~/.bashrc
     mysql -u root -e "flush privileges;"
     sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf
     echo "disable_log_bin"
-    echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mysql.conf.d/mysqld.cnf
+    echo -e "log_bin = 0\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mysql.conf.d/mysqld.cnf
     echo "REPOSITORY_PASSWORD=otnodedb" >> /root/ot-node/current/.env
     echo "NODE_ENV=testnet" >> /root/ot-node/current/.env
     cd /root/ot-node/current


### PR DESCRIPTION
```shell
[ERROR] [MY-000068] [Server] unknown option '---e disable_log_bin'.
[ERROR] [MY-010119] [Server] Aborting
```

```shell
systemctl restart mysql
Job for mysql.service failed because the control process exited with error code.
See "systemctl status mysql.service" and "journalctl -xeu mysql.service" for details.
```