### PR TITLE
Latest Updates for edge-node-installer

### DIFF
--- a/edge-node-installer.sh
+++ b/edge-node-installer.sh
@@ -73,11 +73,11 @@ fi
 
 
 #configure edge-node components github repositories
-edge_node_knowledge_mining="https://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@github.com/OriginTrail/edge-node-knowledge-mining.git"
-edge_node_auth_service="https://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@github.com/OriginTrail/edge-node-authentication-service.git"
-edge_node_drag="https://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@github.com/OriginTrail/edge-node-drag.git"
-edge_node_api="https://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@github.com/OriginTrail/edge-node-api.git"
-edge_node_interface="https://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@github.com/OriginTrail/edge-node-interface.git"
+edge_node_knowledge_mining="https://github.com/OriginTrail/edge-node-knowledge-mining.git"
+edge_node_auth_service="https://github.com/OriginTrail/edge-node-authentication-service.git"
+edge_node_drag="https://github.com/OriginTrail/edge-node-drag.git"
+edge_node_api="https://github.com/OriginTrail/edge-node-api.git"
+edge_node_interface="https://github.com/OriginTrail/edge-node-interface.git"
 
 
 OTNODE_DIR="/root/ot-node"


### PR DESCRIPTION
- Fix node js installation conflict  issues  (clearly define the node js version instead of just stating 22 we should define 22.9.0 due to conflict with 22.10.0).

- Add running as sudo catch mechanism in the script and check if the current user is root before proceeding with installation.

- Add checking for existing edge-node components directories & DKG Core node directory on server before proceeding with installation 
- Removed the Github token for edge-node-installer since repos will be public.
