### PR TITLE
fix/installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ MILVUS_URI=""
 #### PARAMS RELATED TO ON-SERVER DEPLOYMENT ====================================================================
 
 # MYSQL
-SQL_PASSWORD=otnodedb
+SQL_PASSWORD=root
 
 # ENGINE NODE
 # BLOCKCHAIN_ENVIRONMENT can be mainnet or testnet

--- a/edge-node-installer.sh
+++ b/edge-node-installer.sh
@@ -169,14 +169,14 @@ sudo ln -s $(which npm) /usr/bin/ > /dev/null 2>&1
 
 #Setup MySql
     apt install tcllib mysql-server -y
-    mysql -u root -p"$SQL_PASSWORD" -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
+    mysql -u root -p"$SQL_PASSWORD" -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
     mysql -u root -e "CREATE DATABASE operationaldb /*\!40100 DEFAULT CHARACTER SET utf8 */;"
     mysql -u root -e "CREATE DATABASE \`edge-node-auth-service\`"
     mysql -u root -e "CREATE DATABASE \`edge-node-backend\`;"
     mysql -u root -e "CREATE DATABASE drag_logging;"
     mysql -u root -e "CREATE DATABASE ka_mining_api_logging;"
     mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'otnodedb';"
-    mysql -u root -e "flush privileges;"
+    mysql -u root -p"otnodedb" -e "flush privileges;"
     sed -i 's|max_binlog_size|#max_binlog_size|' /etc/mysql/mysql.conf.d/mysqld.cnf
     echo "disable_log_bin"
     echo -e "disable_log_bin\nwait_timeout = 31536000\ninteractive_timeout = 31536000" >> /etc/mysql/mysql.conf.d/mysqld.cnf


### PR DESCRIPTION
Example env pass change, flush command requires pass. 

Assuming the user sets mysql from the installer, it should make sense to keep the example env password for mysql in sync with the defaults - root as default password.